### PR TITLE
Temporarily enable developer exception pages

### DIFF
--- a/WorkoutTracker.Server.WebAPI/Program.cs
+++ b/WorkoutTracker.Server.WebAPI/Program.cs
@@ -50,7 +50,6 @@ public class Program
 
         app.UseSwagger();
         app.UseSwaggerUI();
-
         app.UseCors(options =>
         {
             options.AllowAnyOrigin();
@@ -62,6 +61,7 @@ public class Program
 
         app.UseAuthentication();
         app.UseAuthorization();
+        app.UseDeveloperExceptionPage();
 
         app.MapControllers();
 


### PR DESCRIPTION
Temporarily enable developer exception pages to try to understand why app does not work after postgre migration